### PR TITLE
feat: Add rego checks for teams

### DIFF
--- a/example-data/testorg-unremediated.json
+++ b/example-data/testorg-unremediated.json
@@ -1,4 +1,5 @@
 {
+  "settings": {
     "login": "test-org",
     "id": 1234567,
     "node_id": "O_abcdefg",
@@ -43,11 +44,11 @@
     "members_can_create_public_pages": true,
     "members_can_create_private_pages": true,
     "plan": {
-        "name": "free",
-        "space": 976562499,
-        "private_repos": 10000,
-        "filled_seats": 2,
-        "seats": 1
+      "name": "free",
+      "space": 976562499,
+      "private_repos": 10000,
+      "filled_seats": 2,
+      "seats": 1
     },
     "advanced_security_enabled_for_new_repositories": false,
     "dependabot_alerts_enabled_for_new_repositories": false,
@@ -58,4 +59,5 @@
     "secret_scanning_push_protection_custom_link_enabled": false,
     "secret_scanning_push_protection_custom_link": null,
     "secret_scanning_validity_checks_enabled": false
+  }
 }

--- a/example-data/testorg.json
+++ b/example-data/testorg.json
@@ -1,4 +1,5 @@
 {
+  "settings": {
     "login": "test-org",
     "id": 1234567,
     "node_id": "O_abcdefg",
@@ -43,11 +44,11 @@
     "members_can_create_public_pages": false,
     "members_can_create_private_pages": true,
     "plan": {
-        "name": "free",
-        "space": 976562499,
-        "private_repos": 10000,
-        "filled_seats": 2,
-        "seats": 1
+      "name": "free",
+      "space": 976562499,
+      "private_repos": 10000,
+      "filled_seats": 2,
+      "seats": 1
     },
     "advanced_security_enabled_for_new_repositories": true,
     "dependabot_alerts_enabled_for_new_repositories": true,
@@ -58,4 +59,5 @@
     "secret_scanning_push_protection_custom_link_enabled": true,
     "secret_scanning_push_protection_custom_link": null,
     "secret_scanning_validity_checks_enabled": true
+  }
 }

--- a/policies/gh_org_mfa_enabled.rego
+++ b/policies/gh_org_mfa_enabled.rego
@@ -1,7 +1,7 @@
 package compliance_framework.mfa_enabled
 
 violation[{}] if {
-    input.two_factor_requirement_enabled == false
+    input.settings.two_factor_requirement_enabled == false
 }
 
 title := "Two Factor Authentication is required at an organization level"

--- a/policies/gh_org_mfa_enabled_test.rego
+++ b/policies/gh_org_mfa_enabled_test.rego
@@ -2,12 +2,16 @@ package compliance_framework.mfa_enabled
 
 test_mfa_enabled if {
     count(violation) == 0 with input as {
-        "two_factor_requirement_enabled": true
+        "settings": {
+            "two_factor_requirement_enabled": true
+        }
     }
 }
 
 test_mfa_violate_if_disabled if {
     count(violation) > 0 with input as {
-        "two_factor_requirement_enabled": false
+        "settings": {
+            "two_factor_requirement_enabled": false
+        }
     }
 }

--- a/policies/gh_org_public_repos.rego
+++ b/policies/gh_org_public_repos.rego
@@ -1,15 +1,15 @@
 package compliance_framework.public_repos
 
-checks["repos"] if {
-	input.public_repos > 0
+_checks["repos"] if {
+	input.settings.public_repos > 0
 }
 
-checks["gists"] if {
-	input.public_gists > 0
+_checks["gists"] if {
+	input.settings.public_gists > 0
 }
 
 violation[{}] if {
-	some check in checks
+	some check in _checks
 }
 
 

--- a/policies/gh_org_public_repos_test.rego
+++ b/policies/gh_org_public_repos_test.rego
@@ -2,14 +2,18 @@ package compliance_framework.public_repos
 
 test_public_repos_is_zero if {
     count(violation) == 0 with input as {
-        "pubic_repos": 0,
-        "public_gists": 0
+        "settings": {
+            "public_repos": 0,
+            "public_gists": 0
+        }
     }
 }
 
 test_public_repos_violate_when_higher if {
     count(violation) > 0 with input as {
-        "public_repos": 10,
-        "public_gists": 0
+        "settings": {
+            "public_repos": 10,
+            "public_gists": 0
+        }
     }
 }

--- a/policies/gh_teams_privacy_closed.rego
+++ b/policies/gh_teams_privacy_closed.rego
@@ -1,0 +1,9 @@
+package compliance_framework.teams_privacy_closed
+
+violation[{}] if {
+    some team in input.teams
+    team.privacy != "closed"
+}
+
+title := "All teams are private within the organization"
+description := "All teams within the organization must be set to private to ensure sensitive information is not exposed."

--- a/policies/gh_teams_privacy_closed_test.rego
+++ b/policies/gh_teams_privacy_closed_test.rego
@@ -1,0 +1,31 @@
+package compliance_framework.teams_privacy_closed
+
+test_teams_privacy_closed if {
+    count(violation) == 0 with input as {
+        "teams": [
+            {
+                "name": "team1",
+                "privacy": "closed"
+            },
+            {
+                "name": "team2",
+                "privacy": "closed"
+            }
+        ]
+    }
+}
+
+test_teams_privacy_open if {
+    count(violation) > 0 with input as {
+        "teams": [
+            {
+                "name": "team1",
+                "privacy": "open"
+            },
+            {
+                "name": "team2",
+                "privacy": "closed"
+            }
+        ]
+    }
+}

--- a/policies/gh_teams_security_found.rego
+++ b/policies/gh_teams_security_found.rego
@@ -1,0 +1,18 @@
+package compliance_framework.teams_security_found
+
+_team_with_security if {
+    some team in input.teams
+    contains(team.name, "security")
+}
+
+_team_with_security if {
+    some team in input.teams
+    contains(team.description, "security")
+}
+
+violation[{}] if {
+    not _team_with_security
+}
+
+title := "Security Teams are present within Github"
+description := "A dedicated security team should be created in the organization to manage security-related tasks and incidents, as well as provide consulting when required."

--- a/policies/gh_teams_security_found.rego
+++ b/policies/gh_teams_security_found.rego
@@ -2,12 +2,12 @@ package compliance_framework.teams_security_found
 
 _team_with_security if {
     some team in input.teams
-    contains(team.name, "security")
+    contains(lower(team.name), "security")
 }
 
 _team_with_security if {
     some team in input.teams
-    contains(team.description, "security")
+    contains(lower(team.description), "security")
 }
 
 violation[{}] if {


### PR DESCRIPTION
This pull request updates the organization compliance policies to standardize the input data structure and adds two new policies for team privacy and security team presence. The main changes include refactoring existing policies to expect organization settings under a `settings` object, updating related test cases, and introducing new policies to check for private teams and the existence of a security team.

**Refactoring for standardized input structure:**

* Updated `gh_org_mfa_enabled.rego` and `gh_org_public_repos.rego` policies to reference organization settings under `input.settings`, ensuring consistency in how input data is accessed. [[1]](diffhunk://#diff-f4fee7a13a29f693dda21db47d7df2f1f4f4250cae0c367524ed246d7467c246L4-R4) [[2]](diffhunk://#diff-29560f3dacccaec65ccc481ce34c3be80e9bee41f9a6955bb89f951fe45e62dcL3-R12)
* Modified associated test files (`gh_org_mfa_enabled_test.rego`, `gh_org_public_repos_test.rego`) to match the new input structure, wrapping relevant fields in a `settings` object. [[1]](diffhunk://#diff-159d027e06187d043a2802eee2e87d2057b2656eb1863b39e468ae07ff60dd82R5-R17) [[2]](diffhunk://#diff-baea8e6e49bf1172de50e943b464bb65cd5f167244d12d5d4d2e0e022ca4b4f0L5-R19)
* Updated example data files (`testorg.json`, `testorg-unremediated.json`) to include a top-level `settings` object, supporting the refactored policies. [[1]](diffhunk://#diff-9b3de88347a80b19713ed6dac706db16061ae30b275c5868351a6e653c0e0683R2) [[2]](diffhunk://#diff-9b3de88347a80b19713ed6dac706db16061ae30b275c5868351a6e653c0e0683R63) [[3]](diffhunk://#diff-84b91b90ad2555ad2fd7ac9dc00a8264eee9472f9139ed43ab5f22db9853fffeR2) [[4]](diffhunk://#diff-84b91b90ad2555ad2fd7ac9dc00a8264eee9472f9139ed43ab5f22db9853fffeR63)

**New team-related compliance policies:**

* Added `gh_teams_privacy_closed.rego` and its test file to enforce that all teams in the organization must have privacy set to `closed`. [[1]](diffhunk://#diff-8e3e7e0255365a290fd180cf2702821ca1a848b8315fbbfe0114d0775442630dR1-R9) [[2]](diffhunk://#diff-cddee05daa8df8749675662cc731d487925af60a82b63a86a1ecdcffb08800c6R1-R31)
* Introduced `gh_teams_security_found.rego` to require the presence of a security-focused team, identified by name or description, within the organization.